### PR TITLE
Add a feature to convert just one process.

### DIFF
--- a/src/shoobx/flowview/cli.py
+++ b/src/shoobx/flowview/cli.py
@@ -16,6 +16,9 @@ parser = argparse.ArgumentParser(
     description='Shoobx Flowview: XPDL Viewer')
 parser.add_argument("xpdl", help="Input XPDL filename")
 parser.add_argument("html", help="Output HTML filename")
+parser.add_argument(
+    "--process", default='',
+    help="Limit the output to the given process")
 
 
 def setup_logging(args):
@@ -32,7 +35,7 @@ def main():
     setup_logging(args)
     log.info("Shoobx Flowview %s" % get_version())
 
-    html = xpdl.transform_to_html(args.xpdl)
+    html = xpdl.transform_to_html(args.xpdl, args.process)
 
     with (open(args.html, "w")) as f:
         f.write(html)

--- a/src/shoobx/flowview/tests/test_xpdl.py
+++ b/src/shoobx/flowview/tests/test_xpdl.py
@@ -13,7 +13,8 @@ def test_transform_to_html():
     here = os.path.dirname(__file__)
     samples_dir = os.path.join(here, 'samples')
 
-    output = xpdl.transform_to_html(os.path.join(samples_dir, "samples.xpdl"))
+    output = xpdl.transform_to_html(
+        os.path.join(samples_dir, "samples.xpdl"), '')
 
     assert output.startswith('<!DOCTYPE html>')
 
@@ -31,3 +32,17 @@ def test_transform_to_html():
         'Conditional Transitions',
         'Sample Subflow'
     ]
+
+
+def test_transform_to_html_single_process():
+    here = os.path.dirname(__file__)
+    samples_dir = os.path.join(here, 'samples')
+
+    output = xpdl.transform_to_html(
+        os.path.join(samples_dir, "samples.xpdl"),
+        'schedule_process')
+
+    assert output.startswith('<!DOCTYPE html>')
+
+    processes = re.findall('<h2.*?>(.*?) <small>.*?</h2>', output)
+    assert processes == ['Schedule Process']

--- a/src/shoobx/flowview/xpdl.py
+++ b/src/shoobx/flowview/xpdl.py
@@ -23,7 +23,7 @@ class ResourceResolver(etree.Resolver):
             return self.resolve_file(res, context)
 
 
-def transform_to_html(xpdl_filename):
+def transform_to_html(xpdl_filename, process=''):
     """Transform given XPDL file to HTML
     """
     parser = etree.XMLParser()
@@ -34,7 +34,7 @@ def transform_to_html(xpdl_filename):
     xslt = etree.parse(template, parser)
     template.close()
     transform = etree.XSLT(xslt)
-    htmldom = transform(dom)
+    htmldom = transform(dom, process='"{}"'.format(process))
     # html = etree.tostring(htmldom, pretty_print=True)
     html = str(htmldom)
     return "<!DOCTYPE html>\n" + html

--- a/src/shoobx/flowview/xpdl.xslt
+++ b/src/shoobx/flowview/xpdl.xslt
@@ -3,6 +3,7 @@
 <xsl:stylesheet version="1.0"
   xmlns:xpdl="http://www.wfmc.org/2008/XPDL2.1" xmlns="http://www.wfmc.org/2008/XPDL2.1"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:param name="process" />
 
   <xsl:output method="html" indent="yes" encoding="UTF-8" />
 
@@ -423,7 +424,9 @@
     </h1>
 
     <xsl:for-each select="//xpdl:WorkflowProcesses/xpdl:WorkflowProcess">
-      <xsl:call-template name="process" />
+      <xsl:if test="$process='' or @Id=$process">
+        <xsl:call-template name="process" />
+      </xsl:if>
     </xsl:for-each>
   </xsl:template>
 


### PR DESCRIPTION
On extremely large XPDLs it's unwieldy to have everything in one file.

This feature allows crude filtering on process id.  All the packages still appear in the output, but many are empty when the filter is applied.